### PR TITLE
add app.json to manifest output

### DIFF
--- a/API/src/modules/expo/manifest.js
+++ b/API/src/modules/expo/manifest.js
@@ -59,7 +59,11 @@ module.exports.hanldeManifestData = async (app, { query, headers }) => {
         runtimeVersion,
         platform,
         ext: null
-      })
+      }),
+      metadata: {},
+      extra: {
+        expoClient: update.appJson
+      }
     }
 
     const assetRequestHeaders = {};


### PR DESCRIPTION
This is important so that Constants.expoConfig from the package "expo-constants" will still be populated after an eas update.

fixes #31  and #13

I verified manually for me, that this fixes the issue.