### PR TITLE
reply with requested protocol version

### DIFF
--- a/API/src/modules/expo/manifest.js
+++ b/API/src/modules/expo/manifest.js
@@ -94,7 +94,7 @@ module.exports.hanldeManifestData = async (app, { query, headers }) => {
 }
 
 module.exports.handleManifestResponse = (res, protocolVersion) => {
-  res.set('expo-protocol-version', protocolVersion)
+  res.set('expo-protocol-version', protocolVersion ?? 0)
   res.set('expo-sfv-version', 0)
   res.set('cache-control', 'private, max-age=0')
   res.set('content-type', `multipart/mixed; boundary=${res.data.formBoundary}`)

--- a/API/src/modules/expo/manifest.js
+++ b/API/src/modules/expo/manifest.js
@@ -93,8 +93,8 @@ module.exports.hanldeManifestData = async (app, { query, headers }) => {
   }
 }
 
-module.exports.handleManifestResponse = (res) => {
-  res.set('expo-protocol-version', 0)
+module.exports.handleManifestResponse = (res, protocolVersion) => {
+  res.set('expo-protocol-version', protocolVersion)
   res.set('expo-sfv-version', 0)
   res.set('cache-control', 'private, max-age=0')
   res.set('content-type', `multipart/mixed; boundary=${res.data.formBoundary}`)

--- a/API/src/services/api.js
+++ b/API/src/services/api.js
@@ -95,7 +95,9 @@ module.exports = {
   name: 'api',
   createService: (options) => apiService,
   middleware: (req, res, next) => {
-    if (res.data.type === 'manifest') return handleManifestResponse(res)
+    const protocolVersion = req.headers["expo-protocol-version"];
+
+    if (res.data.type === 'manifest') return handleManifestResponse(res, protocolVersion)
     if (res.data.type === 'asset') return handleAssetResponse(res)
     next()
   },


### PR DESCRIPTION
Android at the moment uses protocol version 0 and ios protocol version 1 (at sdk 51). I had some issues with the ios updated process that seem to be working now, when replying with the requested protocoll version.

Technically just echoing the version as in this solution is of course not the best, but it is a very low effort fix that works for now.