### PR TITLE
Remove experimental param for expo export

### DIFF
--- a/API/public/expo-publish-selfhosted.sh
+++ b/API/public/expo-publish-selfhosted.sh
@@ -69,7 +69,7 @@ rm -f $BUILDFOLDER.zip
 mkdir $BUILDFOLDER
 
 # Build update
-yarn expo export --experimental-bundle --output-dir $BUILDFOLDER
+yarn expo export --output-dir $BUILDFOLDER
 
 # Add app.json & package.json to the build for info & Metadata
 cp app.json $BUILDFOLDER/

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Use the web interface to add your application, just enter the expo slug name
 
 ## Setup a script to publish updates
 You can download the ready to use publish script or create your own, the script logic is simple: 
-- use `expo publish --experimental-bundle` to generate an update
+- use `expo export` to generate an update
 - Add app.json and package.json to the build folder
 - Zip the build folder
 - use curl to push the zip file to the server

--- a/Web/src/Pages/App/UpdateInstructions.jsx
+++ b/Web/src/Pages/App/UpdateInstructions.jsx
@@ -3,7 +3,7 @@ import { FC, useCQuery } from '../../Services'
 
 const getSnippet = ({ server, slug, uploadKey }) => `# Expo publish to local folder
 cd /my/app/folder
-yarn expo export --experimental-bundle --output-dir /path/to/build/folder
+yarn expo export --output-dir /path/to/build/folder
 
 # Add app.json & package.json to the build for info & Metadata
 cp app.json /path/to/build/folder/

--- a/expo-publish-selfhosted.sh
+++ b/expo-publish-selfhosted.sh
@@ -69,7 +69,7 @@ rm -f $BUILDFOLDER.zip
 mkdir $BUILDFOLDER
 
 # Build update
-yarn expo export --experimental-bundle --output-dir $BUILDFOLDER
+yarn expo export --output-dir $BUILDFOLDER
 
 # Add app.json & package.json to the build for info & Metadata
 cp app.json $BUILDFOLDER/


### PR DESCRIPTION
The "new" bundle format is not experimental anymore. Thus the experimental parameter can be omitted, as it is not doing anything at the moment.