### PR TITLE
Fix Windows Expo Export Data  Include \\ Problem

### DIFF
--- a/API/src/modules/expo/helpers.js
+++ b/API/src/modules/expo/helpers.js
@@ -38,7 +38,8 @@ module.exports.getPrivateKeyAsync = async () => {
 }
 
 module.exports.getAssetMetadataSync = ({ update, filePath, ext, isLaunchAsset, platform }) => {
-  const assetFilePath = `${update.path}/${filePath}`
+  const normalizedFilePath = path.normalize(filePath).replace(/\\/g, '/');
+  const assetFilePath = path.join(update.path, normalizedFilePath);
   const asset = fs.readFileSync(path.resolve(assetFilePath), null)
   const assetHash = getBase64URLEncoding(createHash(asset, 'sha256', 'base64'))
   const key = createHash(asset, 'md5', 'hex')

--- a/API/src/modules/expo/manifest.js
+++ b/API/src/modules/expo/manifest.js
@@ -93,7 +93,7 @@ module.exports.hanldeManifestData = async (app, { query, headers }) => {
       formData: form.getBuffer().toString()
     }
   } catch (error) {
-    throw new Err.BadRequest(JSON.stringify('error'))
+    throw new Err.BadRequest(JSON.stringify(error))
   }
 }
 


### PR DESCRIPTION
windows exported expo metadata path has '\\'.But linux server can’t read successful.
![meta](https://github.com/user-attachments/assets/fd48cc73-2e06-4afd-be75-b90ce7d7e99b)
