### PR TITLE
Fixed mongodb connection string options

### DIFF
--- a/API/src/modules/mongodb.js
+++ b/API/src/modules/mongodb.js
@@ -2,7 +2,8 @@ const MongoClient = require('mongodb').MongoClient
 
 module.exports = function (app) {
   const connection = app.get('mongodb')
-  const database = connection.substr(connection.lastIndexOf('/') + 1)
+  const dbNameEndIndex = connection.includes('?') ? connection.indexOf('?') : connection.length
+  const database = connection.substring(connection.lastIndexOf('/') + 1, dbNameEndIndex)
   const mongoClient = MongoClient.connect(connection).then(client => client.db(database))
   app.set('mongoClient', mongoClient)
 }


### PR DESCRIPTION
If some options is used in connection string, wrong interpolation of database name was used.

```bash
mongodb:/user:pass@host:10255/database?ssl=true
```
is workning well now